### PR TITLE
Fix the tenantid regeneration logic

### DIFF
--- a/smoothwall-tools/tenren.pl
+++ b/smoothwall-tools/tenren.pl
@@ -50,6 +50,7 @@ for(keys %{$thash->{'data'}})
 			my $newpol = $poldir . "/" . $newguid;
 			print STDERR "Moving $oldpol $newpol\n";
 			system("/bin/mv $oldpol $newpol") unless $dry;
+			system("/bin/sed -i 's/$oldguid/$newguid/g' $newpol") unless $dry;
 		}
 
 		#Cats


### PR DESCRIPTION
The script that regenerates valid tenant IDs was missing some logic to
rename the tenantID inside the policy table for tenanted policy objects.
For instance, a filter group would be referred as filter:2:<bad_tenant_id>.

The sed command is simple, however it could cause drama if bad tenant
IDs are small integers. Fortunately, it seems that most of invalid tenants
out there are vaguely similar to GUIDs.. so we shall be fine!

Tested on a customer's escalation where this script caused a complete
mess due to that bug.